### PR TITLE
timeout: use new api and bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,14 +4,14 @@ description = "Monoio Transporter."
 edition = "2021"
 license = "MIT/Apache-2.0"
 name = "monoio-transports"
-version = "0.3.2"
+version = "0.3.3"
 
 [dependencies]
 monoio = "0.2.0"
 monoio-compat = "0.2.0"
 service-async = "0.2.0"
 monoio-rustls = "0.3.0"
-monoio-http = "0.3.1"
+monoio-http = "0.3.2"
 monoio-codec = "0.3.1"
 monoio-native-tls = { version = "0.3.0", optional = true }
 

--- a/src/http/connector.rs
+++ b/src/http/connector.rs
@@ -38,7 +38,10 @@ where
             .connect(key)
             .await
             .map_err(|e| e.into())?;
-        Ok(HttpConnection::H1(ClientCodec::new(io, self.timeout)))
+        match self.timeout {
+            Some(timeout) => Ok(HttpConnection::H1(ClientCodec::new_with_timeout(io, timeout))),
+            None => Ok(HttpConnection::H1(ClientCodec::new(io))),
+        }
     }
 }
 

--- a/src/http/connector.rs
+++ b/src/http/connector.rs
@@ -8,18 +8,22 @@ use crate::connectors::Connector;
 #[derive(Clone)]
 pub struct HttpConnector<C> {
     inner_connector: C,
-    pub timeout: Option<Duration>,
+    timeout: Option<Duration>,
 }
 
 impl<C> HttpConnector<C> {
-    pub fn new(inner_connector: C, timeout: Option<Duration>) -> Self {
+    pub fn new(inner_connector: C) -> Self {
+        Self { inner_connector, timeout: None }
+    }
+
+    pub fn new_with_timeout(inner_connector: C, timeout: Option<Duration>) -> Self {
         Self { inner_connector, timeout }
     }
 }
 
 impl<C: Default> Default for HttpConnector<C> {
     fn default() -> Self {
-        HttpConnector::new(C::default(), None)
+        HttpConnector::new(C::default())
     }
 }
 


### PR DESCRIPTION
Use the new monoio-http api's.