### PR TITLE
fix: check connection before returned; remove default pool idle task when not passing idle_interval

### DIFF
--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -20,8 +20,6 @@ pub(crate) const DEFAULT_KEEPALIVE_CONNS: usize = 256;
 pub(crate) const DEFAULT_POOL_SIZE: usize = 32;
 // https://datatracker.ietf.org/doc/html/rfc6335
 pub(crate) const MAX_KEEPALIVE_CONNS: usize = 16384;
-#[cfg(feature = "time")]
-pub(crate) const DEFAULT_IDLE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
 
 pub trait Poolable {
     fn is_open(&self) -> bool;
@@ -175,7 +173,7 @@ impl<T: Poolable, K: Key> Drop for Pooled<K, T> {
 }
 
 pub(crate) struct Idle<IO> {
-    conn: IO,
+    pub(crate) conn: IO,
     idle_at: Instant,
 }
 
@@ -193,35 +191,52 @@ impl<IO> Idle<IO> {
     pub(crate) fn expired(&self, max_elapsed: Duration) -> bool {
         self.idle_at.elapsed() > max_elapsed
     }
+
+    #[allow(unused)]
+    #[inline]
+    pub(crate) fn expired_opt(&self, max_elapsed: Option<Duration>) -> bool {
+        match max_elapsed {
+            Some(e) => self.idle_at.elapsed() > e,
+            None => false,
+        }
+    }
+
+    #[allow(unused)]
+    #[inline]
+    pub(crate) fn reset_idle(&mut self) {
+        self.idle_at = Instant::now()
+    }
 }
 
 pub(crate) struct PoolInner<K, IO> {
     idle_conns: HashMap<K, VecDeque<Idle<IO>>>,
     max_idle: usize,
     #[cfg(feature = "time")]
-    _drop: local_sync::oneshot::Receiver<()>,
+    idle_dur: Option<Duration>,
+    #[cfg(feature = "time")]
+    _drop: Option<local_sync::oneshot::Receiver<()>>,
 }
 
 impl<K, IO> PoolInner<K, IO> {
     #[cfg(feature = "time")]
-    fn new(max_idle: Option<usize>) -> (local_sync::oneshot::Sender<()>, Self) {
+    fn new_with_dropper(max_idle: Option<usize>) -> (local_sync::oneshot::Sender<()>, Self) {
         let idle_conns = HashMap::with_capacity(DEFAULT_POOL_SIZE);
         let max_idle = max_idle
             .map(|n| n.min(MAX_KEEPALIVE_CONNS))
             .unwrap_or(DEFAULT_KEEPALIVE_CONNS);
 
-        let (tx, _drop) = local_sync::oneshot::channel();
+        let (tx, drop) = local_sync::oneshot::channel();
         (
             tx,
             Self {
                 idle_conns,
                 max_idle,
-                _drop,
+                idle_dur: None,
+                _drop: Some(drop),
             },
         )
     }
 
-    #[cfg(not(feature = "time"))]
     fn new(max_idle: Option<usize>) -> Self {
         let idle_conns = HashMap::with_capacity(DEFAULT_POOL_SIZE);
         let max_idle = max_idle
@@ -230,6 +245,10 @@ impl<K, IO> PoolInner<K, IO> {
         Self {
             idle_conns,
             max_idle,
+            #[cfg(feature = "time")]
+            idle_dur: None,
+            #[cfg(feature = "time")]
+            _drop: None,
         }
     }
 
@@ -259,35 +278,39 @@ impl<K, T> Clone for ConnectionPool<K, T> {
 impl<K: 'static, T: 'static> ConnectionPool<K, T> {
     #[cfg(feature = "time")]
     pub fn new_with_idle_interval(
+        // `idle_interval` controls how often the pool will check for idle connections.
+        // It is also used to determine if a connection is expired.
         idle_interval: Option<Duration>,
+        // `max_idle` is max idle connection count
         max_idle: Option<usize>,
     ) -> Self {
         const MIN_INTERVAL: Duration = Duration::from_secs(1);
 
-        let (tx, inner) = PoolInner::new(max_idle);
-        let shared = Rc::new(UnsafeCell::new(inner));
-        let idle_interval = idle_interval.unwrap_or(DEFAULT_IDLE_INTERVAL);
-        monoio::spawn(IdleTask {
-            tx,
-            conns: Rc::downgrade(&shared),
-            interval: monoio::time::interval(idle_interval.max(MIN_INTERVAL)),
-            idle_dur: idle_interval,
-        });
+        if let Some(idle_interval) = idle_interval {
+            let idle_dur = idle_interval;
+            let idle_interval = idle_interval.max(MIN_INTERVAL);
 
-        Self { shared }
+            let (tx, inner) = PoolInner::new_with_dropper(max_idle);
+            let shared = Rc::new(UnsafeCell::new(inner));
+            monoio::spawn(IdleTask {
+                tx,
+                conns: Rc::downgrade(&shared),
+                interval: monoio::time::interval(idle_interval),
+                idle_dur,
+            });
+
+            Self { shared }
+        } else {
+            let shared = Rc::new(UnsafeCell::new(PoolInner::new(max_idle)));
+            Self { shared }
+        }
     }
 
-    #[cfg(feature = "time")]
     #[inline]
     pub fn new(max_idle: Option<usize>) -> Self {
-        Self::new_with_idle_interval(None, max_idle)
-    }
-
-    #[cfg(not(feature = "time"))]
-    #[inline]
-    pub fn new(max_idle: Option<usize>) -> Self {
-        let shared = Rc::new(UnsafeCell::new(PoolInner::new(max_idle)));
-        Self { shared }
+        Self {
+            shared: Rc::new(UnsafeCell::new(PoolInner::new(max_idle))),
+        }
     }
 }
 
@@ -304,6 +327,27 @@ impl<K: Key, T: Poolable> ConnectionPool<K, T> {
     pub fn get(&self, key: &K) -> Option<Pooled<K, T>> {
         let inner = unsafe { &mut *self.shared.get() };
 
+        #[cfg(feature = "time")]
+        loop {
+            let r = match inner.idle_conns.get_mut(key) {
+                Some(v) => match v.pop_front() {
+                    Some(idle) if !idle.expired_opt(inner.idle_dur) => Some(Pooled::new(
+                        key.to_owned(),
+                        idle.conn,
+                        true,
+                        Rc::downgrade(&self.shared),
+                    )),
+                    Some(_) => {
+                        continue;
+                    }
+                    None => None,
+                },
+                None => None,
+            };
+            return r;
+        }
+
+        #[cfg(not(feature = "time"))]
         match inner.idle_conns.get_mut(key) {
             Some(v) => match v.pop_front() {
                 Some(idle) => Some(Pooled::new(
@@ -336,17 +380,29 @@ impl<K: Key, T: Poolable> ConnectionPool<K, T> {
         queue.push_back(idle);
     }
 
-    /// Get a reference to the element and apply f.
+    /// Get a reference to the element and apply f with map.
     /// Mostly use by h2.
     #[inline]
-    pub fn map_ref<F: FnOnce(&T) -> O, O>(&self, key: &K, f: F) -> Option<O> {
+    #[allow(unused)]
+    pub(crate) fn map_mut<F: FnOnce(&mut VecDeque<Idle<T>>) -> O, O>(
+        &self,
+        key: &K,
+        f: F,
+    ) -> Option<O> {
         let inner = unsafe { &mut *self.shared.get() };
+        inner.idle_conns.get_mut(key).map(f)
+    }
 
-        inner
-            .idle_conns
-            .get_mut(key)
-            .and_then(|conns| conns.front().map(|elem| &elem.conn))
-            .map(f)
+    /// Get a reference to the element and apply f with and_then.
+    /// Mostly use by h2.
+    #[inline]
+    pub(crate) fn and_then_mut<F: FnOnce(&mut VecDeque<Idle<T>>) -> Option<O>, O>(
+        &self,
+        key: &K,
+        f: F,
+    ) -> Option<O> {
+        let inner = unsafe { &mut *self.shared.get() };
+        inner.idle_conns.get_mut(key).and_then(f)
     }
 
     #[inline]


### PR DESCRIPTION
1. Check http connection(h1 and h2) state before returned
2. [default behavior changes!] When `idle_interval` is None, not start background task or expire connection before taking out from pool.

`ConnectionPool::new` behavior changes. If user wants starting `IdleTask`, it have to be changed to `new_with_idle_interval`
