### PR TITLE
Feat: Unified Http connector with HTTP/2 & HTTP/1.1 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,14 +7,13 @@ name = "monoio-transports"
 version = "0.4.4"
 
 [dependencies]
-monoio = "0.2.2"
+monoio = "0.2.3"
 monoio-compat = "0.2.1"
 service-async = "0.2.0"
-monoio-rustls = "0.3.0"
-monoio-http = "0.3.7"
+monoio-rustls = "0.4.0"
+monoio-http = "0.3.8"
 monoio-codec = "0.3.1"
-monoio-native-tls = { version = "0.3.0", optional = true }
-
+monoio-native-tls = { version = "0.4.0", optional = true, features = ["alpn"] }
 bytes = "1"
 http = "1.0"
 local-sync = "0.1"
@@ -24,10 +23,8 @@ serde = "1"
 serde_json = "1"
 smol_str = "0.2"
 
-rustls = { version = "0.21", default-features = false, features = [
-    "dangerous_configuration",
-] }
-webpki-roots = "0.25.2"
+rustls = { version = "~0.23.4"}
+webpki-roots = "~0.26.1"
 native-tls = { version = "0.2", optional = true }
 
 tracing = { version = "0.1", optional = true }

--- a/examples/http_with_tcp.rs
+++ b/examples/http_with_tcp.rs
@@ -1,14 +1,65 @@
 use std::net::ToSocketAddrs;
 
+use bytes::Bytes;
 use http::{request, Uri};
-use monoio_http::{common::body::HttpBody, h1::payload::Payload};
+use monoio::net::TcpListener;
+use monoio_http::{
+    common::{
+        body::{Body, FixedBody, HttpBody},
+        request::Request,
+    },
+    h1::payload::Payload,
+};
 use monoio_transports::{
     connectors::{Connector, TcpConnector},
-    http::H1Connector,
+    http::HttpConnector,
 };
 
+async fn serve_h2(
+    io: monoio::net::TcpStream,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let mut connection = monoio_http::h2::server::handshake(io).await?;
+    println!("H2 connection bound");
+
+    while let Some(result) = connection.accept().await {
+        let (request, send_resp) = result?;
+        monoio::spawn(async move {
+            let (parts, body) = request.into_parts();
+            if let Err(e) =
+                handle_request_h2(Request::from_parts(parts, body.into()), send_resp).await
+            {
+                println!("error while handling request: {e}");
+            }
+        });
+    }
+
+    println!("~~~~~~~~~~~ H2 connection CLOSE !!!!!! ~~~~~~~~~~~");
+    Ok(())
+}
+
+async fn handle_request_h2(
+    mut request: Request<HttpBody>,
+    mut respond: monoio_http::h2::server::SendResponse<bytes::Bytes>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    println!("GOT request: {request:?}");
+
+    let body = request.body_mut();
+    while let Some(data) = body.next_data().await {
+        let data = data?;
+        println!("<<<< recv {data:?}");
+    }
+
+    let response = http::Response::new(());
+    let mut send = respond.send_response(response, false)?;
+    println!(">>>> send");
+    send.send_data(bytes::Bytes::from_static(b"hello "), false)?;
+    send.send_data(bytes::Bytes::from_static(b"world\n"), true)?;
+
+    Ok(())
+}
+
 #[monoio::main]
-async fn main() -> Result<(), monoio_transports::Error> {
+async fn main() -> Result<(), monoio_transports::TransportError> {
     #[derive(Debug, Clone, Eq, PartialEq, Hash)]
     struct Key {
         host: String,
@@ -22,7 +73,8 @@ async fn main() -> Result<(), monoio_transports::Error> {
         }
     }
 
-    let connector: H1Connector<TcpConnector, _, _> = H1Connector::default();
+    // Plain text HTTP_1.1 connector.
+    let connector: HttpConnector<TcpConnector, _, _> = HttpConnector::default();
     let uri = "http://httpbin.org/get".parse::<Uri>().unwrap();
     let host = uri.host().unwrap();
     let port = uri.port_u16().unwrap_or(80);
@@ -46,5 +98,50 @@ async fn main() -> Result<(), monoio_transports::Error> {
     );
     let (header, _) = resp.into_parts();
     println!("resp header: {:?}", header);
+
+    let listener = TcpListener::bind("127.0.0.1:5928").unwrap();
+    println!("listening on {:?}", listener.local_addr());
+    monoio::spawn(async move {
+        loop {
+            if let Ok((socket, _peer_addr)) = listener.accept().await {
+                monoio::spawn(async move {
+                    if let Err(e) = serve_h2(socket).await {
+                        println!("  -> err={e:?}");
+                    }
+                });
+            }
+        }
+    });
+
+    // Construct uri and request
+    let uri = "http://127.0.0.1:5928/get".parse::<Uri>().unwrap();
+    let host = uri.host().unwrap();
+    let port = uri.port_u16().unwrap_or(80);
+    let key = Key {
+        host: host.to_string(),
+        port,
+    };
+
+    // Plain text HTTP_2 connector
+    let connector = HttpConnector::build_tcp_http2_only();
+    for _ in 0..3 {
+        let mut pooled_conn = connector.connect(key.clone()).await.unwrap();
+        let req = http::Request::builder()
+            .uri(uri.clone())
+            .body(HttpBody::fixed_body(Some(Bytes::from_static(
+                b"hello world",
+            ))))
+            .unwrap();
+        let (resp, _) = pooled_conn.send_request(req).await;
+        let resp = resp.unwrap();
+        println!("H2 Response status: {}", resp.status());
+
+        // Get the body
+        let mut body = resp.into_body();
+        while let Some(chunk) = body.next_data().await {
+            println!("GOT CHUNK = {:?}", chunk);
+        }
+    }
+
     Ok(())
 }

--- a/examples/http_with_uds.rs
+++ b/examples/http_with_uds.rs
@@ -2,14 +2,14 @@ use http::request;
 use monoio_http::{common::body::HttpBody, h1::payload::Payload};
 use monoio_transports::{
     connectors::{Connector, UnixConnector},
-    http::H1Connector,
+    http::HttpConnector,
 };
 
 const UDS_PATH: &str = "./examples/uds.sock";
 
 #[monoio::main]
-async fn main() -> Result<(), monoio_transports::Error> {
-    let connector: H1Connector<UnixConnector, _, _> = H1Connector::default();
+async fn main() -> Result<(), monoio_transports::TransportError> {
+    let connector: HttpConnector<UnixConnector, _, _> = HttpConnector::default();
     let mut conn = connector.connect(UDS_PATH).await.unwrap();
     let req = request::Builder::new()
         .uri("/get")

--- a/examples/https_with_tcp.rs
+++ b/examples/https_with_tcp.rs
@@ -2,28 +2,61 @@ use http::{request, Uri};
 use monoio_http::{common::body::HttpBody, h1::payload::Payload};
 use monoio_transports::{
     connectors::{Connector, TcpConnector, TcpTlsAddr, TlsConnector},
-    http::H1Connector,
+    http::HttpConnector,
 };
 
 #[monoio::main]
-async fn main() -> Result<(), monoio_transports::Error> {
-    let connector: H1Connector<TlsConnector<TcpConnector>, _, _> = H1Connector::default();
+async fn main() -> Result<(), monoio_transports::TransportError> {
+    // Https conector with HTTP_2 and HTTP_11 support.
+    // TLS ALPN is set to h2, http/1.1. This will make the connector
+    // to use HTTP_2 if the server supports it, otherwise it will fallback to HTTP_11.
+    let mut connector: HttpConnector<TlsConnector<TcpConnector>, _, _> =
+        HttpConnector::build_tls_http2_only();
+    connector.h2_builder().max_concurrent_streams(150);
     let uri = "https://httpbin.org/get".parse::<Uri>().unwrap();
-    let unified_addr = TcpTlsAddr::try_from(&uri).unwrap();
-    let mut conn = connector.connect(unified_addr).await.unwrap();
-    let req = request::Builder::new()
-        .uri("/get")
-        .header("Host", "httpbin.org")
-        .body(HttpBody::H1(Payload::None))
-        .unwrap();
-    let (res, _) = conn.send_request(req).await;
-    let resp = res?;
-    assert_eq!(200, resp.status());
-    assert_eq!(
-        "application/json".as_bytes(),
-        resp.headers().get("content-type").unwrap().as_bytes()
-    );
-    let (header, _) = resp.into_parts();
-    println!("resp header: {:?}", header);
+    let addr: TcpTlsAddr = uri.try_into().unwrap();
+    let mut conn = connector.connect(addr).await.unwrap();
+
+    for _i in 0..10 {
+        let req = request::Builder::new()
+            .uri("/get")
+            .header("Host", "httpbin.org")
+            .body(HttpBody::H1(Payload::None))
+            .unwrap();
+        let (res, _) = conn.send_request(req).await;
+        let resp = res?;
+        assert_eq!(200, resp.status());
+        assert_eq!(
+            "application/json".as_bytes(),
+            resp.headers().get("content-type").unwrap().as_bytes()
+        );
+
+        assert_eq!(resp.version(), http::Version::HTTP_2);
+    }
+
+    // Https conenctor with HTTP_11 support only.
+    // TLS ALPN is set to http/1.1. This will make the connector to use HTTP_11 only.
+    let connector: HttpConnector<TlsConnector<TcpConnector>, _, _> =
+        HttpConnector::build_tls_http1_only();
+    let uri = "https://httpbin.org/get".parse::<Uri>().unwrap();
+    let addr: TcpTlsAddr = uri.try_into().unwrap();
+    let mut conn = connector.connect(addr).await.unwrap();
+
+    for _i in 0..10 {
+        let req = request::Builder::new()
+            .uri("/get")
+            .header("Host", "httpbin.org")
+            .body(HttpBody::H1(Payload::None))
+            .unwrap();
+        let (res, _) = conn.send_request(req).await;
+        let resp = res?;
+        assert_eq!(200, resp.status());
+        assert_eq!(
+            "application/json".as_bytes(),
+            resp.headers().get("content-type").unwrap().as_bytes()
+        );
+        assert_eq!(resp.version(), http::Version::HTTP_11);
+    }
+
     Ok(())
 }

--- a/src/connectors/l4_connector.rs
+++ b/src/connectors/l4_connector.rs
@@ -10,7 +10,7 @@ use monoio::{
     net::{TcpStream, UnixStream},
 };
 
-use super::Connector;
+use super::{Connector, TransportConnMeta, TransportConnMetadata};
 
 #[derive(Default, Clone, Copy, Debug)]
 pub struct TcpConnector {
@@ -33,6 +33,14 @@ impl<T: ToSocketAddrs> Connector<T> for TcpConnector {
     }
 }
 
+impl TransportConnMetadata for TcpStream {
+    type Metadata = TransportConnMeta;
+
+    fn get_conn_metadata(&self) -> Self::Metadata {
+        TransportConnMeta::default()
+    }
+}
+
 #[derive(Default, Clone, Copy, Debug)]
 pub struct UnixConnector;
 
@@ -43,6 +51,14 @@ impl<P: AsRef<Path>> Connector<P> for UnixConnector {
     #[inline]
     async fn connect(&self, key: P) -> Result<Self::Connection, Self::Error> {
         UnixStream::connect(key).await
+    }
+}
+
+impl TransportConnMetadata for UnixStream {
+    type Metadata = TransportConnMeta;
+
+    fn get_conn_metadata(&self) -> Self::Metadata {
+        TransportConnMeta::default()
     }
 }
 

--- a/src/connectors/mod.rs
+++ b/src/connectors/mod.rs
@@ -34,3 +34,49 @@ impl<K, T: Connector<K>> ConnectorExt<K> for T {
         monoio::time::timeout(timeout, self.connect(key))
     }
 }
+
+/// `TransportConnMetadata` is a trait that provides additional information about the connection.
+/// This is useful for transport connectors like TLS, TCP, UDS etc.
+///
+/// The `get_conn_metadata` method is used to retrieve the metadata from the connection.
+pub trait TransportConnMetadata {
+    type Metadata;
+
+    /// Retrieves the metadata from the connection.
+    ///
+    /// # Returns
+    ///
+    /// An instance of the associated type `Metadata`.
+    fn get_conn_metadata(&self) -> Self::Metadata;
+}
+
+#[derive(Default, Copy, Clone)]
+pub enum Alpn {
+    HTTP2,
+    HTTP11,
+    #[default]
+    None,
+}
+
+/// `TransportConnMeta` is a struct that holds metadata for a transport connection.
+/// It currently only holds the `Alpn` protocol.
+#[derive(Default, Copy, Clone)]
+pub struct TransportConnMeta {
+    alpn: Alpn,
+}
+
+impl TransportConnMeta {
+    pub fn set_alpn(&mut self, alpn: Option<Vec<u8>>) {
+        self.alpn = match alpn {
+            Some(p) if p == b"h2" => Alpn::HTTP2,
+            _ => Alpn::None,
+        }
+    }
+
+    pub fn is_alpn_h2(&self) -> bool {
+        match self.alpn {
+            Alpn::HTTP2 => true,
+            _ => false,
+        }
+    }
+}

--- a/src/connectors/tls_connector.rs
+++ b/src/connectors/tls_connector.rs
@@ -5,7 +5,7 @@ use monoio::io::{AsyncReadRent, AsyncWriteRent, Split};
 use service_async::Param;
 use thiserror::Error as ThisError;
 
-use super::Connector;
+use super::{Connector, TransportConnMeta, TransportConnMetadata};
 use crate::FromUriError;
 
 #[cfg(not(feature = "native-tls"))]
@@ -16,7 +16,7 @@ pub type TlsStream<C> = monoio_native_tls::TlsStream<C>;
 
 #[cfg(feature = "native-tls")]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct ServerName(pub smol_str::SmolStr);
+pub struct TlsServerName(pub smol_str::SmolStr);
 #[cfg(feature = "native-tls")]
 pub use monoio_native_tls::TlsConnector as MonoioTlsConnector;
 #[cfg(feature = "native-tls")]
@@ -25,14 +25,28 @@ pub use monoio_native_tls::TlsError;
 pub use monoio_rustls::TlsConnector as MonoioTlsConnector;
 #[cfg(not(feature = "native-tls"))]
 pub use monoio_rustls::TlsError;
-#[cfg(not(feature = "native-tls"))]
-pub use rustls::ServerName;
 
 #[cfg(feature = "native-tls")]
-impl<T: Into<smol_str::SmolStr>> From<T> for ServerName {
+pub type ServerName<'a> = TlsServerName;
+
+#[cfg(not(feature = "native-tls"))]
+pub type ServerName<'a> = rustls::pki_types::ServerName<'a>;
+
+#[cfg(feature = "native-tls")]
+impl<T: Into<smol_str::SmolStr>> From<T> for ServerName<'static> {
     #[inline]
     fn from(value: T) -> Self {
         Self(value.into())
+    }
+}
+
+impl<S> TransportConnMetadata for TlsStream<S> {
+    type Metadata = TransportConnMeta;
+
+    fn get_conn_metadata(&self) -> Self::Metadata {
+        let mut meta = TransportConnMeta::default();
+        meta.set_alpn(self.alpn_protocol());
+        meta
     }
 }
 
@@ -58,30 +72,35 @@ impl<C> TlsConnector<C> {
 
     #[cfg(not(feature = "native-tls"))]
     #[inline]
-    pub fn new_with_tls_default(inner_connector: C) -> Self {
+    pub fn new_with_tls_default(inner_connector: C, alpn: Option<Vec<Vec<u8>>>) -> Self {
         let mut root_store = rustls::RootCertStore::empty();
-        root_store.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().map(|ta| {
-            rustls::OwnedTrustAnchor::from_subject_spki_name_constraints(
-                ta.subject,
-                ta.spki,
-                ta.name_constraints,
-            )
-        }));
+        root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
 
-        let cfg = rustls::ClientConfig::builder()
-            .with_safe_defaults()
+        let mut cfg = rustls::ClientConfig::builder()
             .with_root_certificates(root_store)
             .with_no_client_auth();
+
+        // Set ALPN from client side
+        if let Some(alpn) = alpn {
+            cfg.alpn_protocols = alpn;
+        }
+
         TlsConnector::new(inner_connector, cfg.into())
     }
 
     #[cfg(feature = "native-tls")]
     #[inline]
-    pub fn new_with_tls_default(inner_connector: C) -> Self {
-        TlsConnector::new(
-            inner_connector,
-            native_tls::TlsConnector::builder().build().unwrap().into(),
-        )
+    pub fn new_with_tls_default(inner_connector: C, alpn: Option<Vec<Vec<u8>>>) -> Self {
+        let mut tls_connector = native_tls::TlsConnector::builder();
+        if let Some(alpn) = alpn {
+            // Convert alpn to &[&str]
+            let alpns = alpn
+                .iter()
+                .map(|a| std::str::from_utf8(a).unwrap())
+                .collect::<Vec<_>>();
+            tls_connector.request_alpns(&alpns);
+        }
+        TlsConnector::new(inner_connector, tls_connector.build().unwrap().into())
     }
 
     #[inline]
@@ -98,13 +117,14 @@ impl<C> TlsConnector<C> {
 impl<C: Default> Default for TlsConnector<C> {
     #[inline]
     fn default() -> Self {
-        TlsConnector::new_with_tls_default(Default::default())
+        let alpn = Some(vec![b"h2".to_vec(), b"http/1.1".to_vec()]);
+        TlsConnector::new_with_tls_default(Default::default(), alpn)
     }
 }
 
 impl<C, T, CN> Connector<T> for TlsConnector<C>
 where
-    T: AsRef<ServerName>,
+    T: AsRef<ServerName<'static>>,
     for<'a> C: Connector<&'a T, Error = std::io::Error, Connection = CN>,
     CN: AsyncReadRent + AsyncWriteRent,
 {
@@ -129,19 +149,19 @@ where
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct UnifiedTlsAddr {
     pub addr: super::UnifiedL4Addr,
-    pub sn: ServerName,
+    pub sn: ServerName<'static>,
 }
 
-impl Param<ServerName> for UnifiedTlsAddr {
+impl Param<ServerName<'static>> for UnifiedTlsAddr {
     #[inline]
-    fn param(&self) -> ServerName {
+    fn param(&self) -> ServerName<'static> {
         self.sn.clone()
     }
 }
 
-impl AsRef<ServerName> for UnifiedTlsAddr {
+impl AsRef<ServerName<'static>> for UnifiedTlsAddr {
     #[inline]
-    fn as_ref(&self) -> &ServerName {
+    fn as_ref(&self) -> &ServerName<'static> {
         &self.sn
     }
 }
@@ -164,19 +184,19 @@ impl AsRef<super::UnifiedL4Addr> for UnifiedTlsAddr {
 pub struct TcpTlsAddr {
     pub host: smol_str::SmolStr,
     pub port: u16,
-    pub sn: ServerName,
+    pub sn: ServerName<'static>,
 }
 
-impl Param<ServerName> for TcpTlsAddr {
+impl Param<ServerName<'static>> for TcpTlsAddr {
     #[inline]
-    fn param(&self) -> ServerName {
+    fn param(&self) -> ServerName<'static> {
         self.sn.clone()
     }
 }
 
-impl AsRef<ServerName> for TcpTlsAddr {
+impl AsRef<ServerName<'static>> for TcpTlsAddr {
     #[inline]
-    fn as_ref(&self) -> &ServerName {
+    fn as_ref(&self) -> &ServerName<'static> {
         &self.sn
     }
 }
@@ -218,7 +238,7 @@ impl TryFrom<&Uri> for TcpTlsAddr {
             }
             #[cfg(not(feature = "native-tls"))]
             {
-                ServerName::try_from(host.as_str())?
+                ServerName::try_from(host.to_string())?
             }
         };
 
@@ -277,19 +297,19 @@ impl<'a> Connector<&'a UnifiedTlsAddr> for UnifiedConnector {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UnifiedAddr {
     pub addr: super::UnifiedL4Addr,
-    pub sn: Option<ServerName>,
+    pub sn: Option<ServerName<'static>>,
 }
 
-impl Param<Option<ServerName>> for UnifiedAddr {
+impl Param<Option<ServerName<'static>>> for UnifiedAddr {
     #[inline]
-    fn param(&self) -> Option<ServerName> {
+    fn param(&self) -> Option<ServerName<'static>> {
         self.sn.clone()
     }
 }
 
-impl AsRef<Option<ServerName>> for UnifiedAddr {
+impl AsRef<Option<ServerName<'static>>> for UnifiedAddr {
     #[inline]
-    fn as_ref(&self) -> &Option<ServerName> {
+    fn as_ref(&self) -> &Option<ServerName<'static>> {
         &self.sn
     }
 }
@@ -314,7 +334,7 @@ impl TryFrom<&Uri> for UnifiedAddr {
     #[inline]
     fn try_from(uri: &Uri) -> Result<Self, Self::Error> {
         let host = match uri.host() {
-            Some(a) => a,
+            Some(a) => a.to_string(),
             None => return Err(FromUriError::NoAuthority),
         };
 
@@ -326,7 +346,7 @@ impl TryFrom<&Uri> for UnifiedAddr {
         let port = uri.port_u16().unwrap_or(default_port);
 
         let l4_addr = super::UnifiedL4Addr::Tcp(
-            (host, port)
+            (host.to_string(), port)
                 .to_socket_addrs()?
                 .next()
                 .ok_or(crate::FromUriError::NoResolve)?,
@@ -339,7 +359,7 @@ impl TryFrom<&Uri> for UnifiedAddr {
             }
             #[cfg(not(feature = "native-tls"))]
             {
-                Some(ServerName::try_from(host)?)
+                Some(ServerName::try_from(host.to_string())?)
             }
         } else {
             None

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use thiserror::Error as ThisError;
 
 #[derive(ThisError, Debug)]
-pub enum Error {
+pub enum TransportError {
     #[error("convert from uri error {0}")]
     FromUri(#[from] FromUriError),
     #[error("http header error")]
@@ -32,14 +32,16 @@ pub enum Error {
     MissingCodec,
     #[error("Validation error {0}")]
     Validation(String),
+    #[error("Acquire lock error {0}")]
+    LockError(#[from] local_sync::semaphore::AcquireError),
 }
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, TransportError>;
 
 #[derive(ThisError, Debug)]
 pub enum FromUriError {
     #[error("Invalid dns name {0}")]
-    InvalidDnsName(#[from] rustls::client::InvalidDnsNameError),
+    InvalidDnsName(#[from] rustls::pki_types::InvalidDnsNameError),
     #[error("Scheme not supported")]
     UnsupportScheme,
     #[error("Missing authority in uri")]

--- a/src/http/connection.rs
+++ b/src/http/connection.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use http::Response;
 use monoio::io::{
     sink::{Sink, SinkExt},
@@ -8,6 +9,8 @@ use monoio_http::{
     common::{
         body::{Body, HttpBody},
         error::HttpError,
+        request::{Request, RequestHead},
+        IntoParts,
     },
     h1::{
         codec::{
@@ -16,28 +19,37 @@ use monoio_http::{
         },
         payload::{fixed_payload_pair, stream_payload_pair, Payload},
     },
+    h2::client::SendRequest,
 };
 
-use crate::pool::Poolable;
+use crate::pool::{Key, Poolable, Pooled};
 
-pub enum HttpConnection<IO: AsyncWriteRent> {
-    H1 {
-        framed: ClientCodec<IO>,
-        using: bool,
-        open: bool,
-    },
+pub struct Http1Connection<IO: AsyncWriteRent> {
+    framed: ClientCodec<IO>,
+    using: bool,
+    open: bool,
 }
 
-impl<IO: AsyncWriteRent> Poolable for HttpConnection<IO> {
-    #[inline]
-    fn is_open(&self) -> bool {
-        match self {
-            Self::H1 { using, open, .. } => *open && !*using,
+impl<IO: AsyncWriteRent> Http1Connection<IO> {
+    pub fn new(framed: ClientCodec<IO>) -> Self {
+        Self {
+            framed,
+            using: false,
+            open: true,
         }
     }
 }
 
-impl<IO: AsyncReadRent + AsyncWriteRent> HttpConnection<IO> {
+impl<IO: AsyncWriteRent> Poolable for Http1Connection<IO> {
+    #[inline]
+    fn is_open(&self) -> bool {
+        match self {
+            Self { using, open, .. } => *open && !*using,
+        }
+    }
+}
+
+impl<IO: AsyncReadRent + AsyncWriteRent> Http1Connection<IO> {
     pub async fn send_request<R, E>(
         &mut self,
         request: R,
@@ -46,86 +58,205 @@ impl<IO: AsyncReadRent + AsyncWriteRent> HttpConnection<IO> {
         ClientCodec<IO>: Sink<R, Error = E>,
         E: std::fmt::Debug + Into<HttpError>,
     {
-        match self {
-            Self::H1 {
-                framed,
-                using,
-                open,
-            } => {
-                *using = true;
-                if let Err(e) = framed.send_and_flush(request).await {
-                    #[cfg(feature = "logging")]
-                    tracing::error!("send upstream request error {:?}", e);
-                    *open = false;
-                    *using = false;
-                    return (Err(e.into()), false);
-                }
+        let handle = &mut self.framed;
 
-                match framed.next().await {
-                    Some(Ok(resp)) => {
-                        let (parts, payload_decoder) = resp.into_parts();
-                        match payload_decoder {
-                            PayloadDecoder::None => {
-                                *using = false;
-                                let payload = Payload::None;
-                                let response = Response::from_parts(parts, payload.into());
-                                (Ok(response), false)
-                            }
-                            PayloadDecoder::Fixed(_) => {
-                                let mut framed_payload = payload_decoder.with_io(framed);
-                                let (payload, payload_sender) = fixed_payload_pair();
-                                if let Some(data) = framed_payload.next_data().await {
-                                    payload_sender.feed(data)
+        if let Err(e) = handle.send_and_flush(request).await {
+            #[cfg(feature = "logging")]
+            tracing::error!("send upstream request error {:?}", e);
+            self.open = false;
+            return (Err(e.into()), false);
+        }
+
+        match handle.next().await {
+            Some(Ok(resp)) => {
+                let (parts, payload_decoder) = resp.into_parts();
+                match payload_decoder {
+                    PayloadDecoder::None => {
+                        let payload = Payload::None;
+                        let response = Response::from_parts(parts, payload.into());
+                        (Ok(response), false)
+                    }
+                    PayloadDecoder::Fixed(_) => {
+                        let mut framed_payload = payload_decoder.with_io(handle);
+                        let (payload, payload_sender) = fixed_payload_pair();
+                        if let Some(data) = framed_payload.next_data().await {
+                            payload_sender.feed(data)
+                        }
+                        let payload = Payload::Fixed(payload);
+                        let response = Response::from_parts(parts, payload.into());
+                        (Ok(response), false)
+                    }
+                    PayloadDecoder::Streamed(_) => {
+                        let mut framed_payload = payload_decoder.with_io(handle);
+                        let (payload, mut payload_sender) = stream_payload_pair();
+                        loop {
+                            match framed_payload.next_data().await {
+                                Some(Ok(data)) => payload_sender.feed_data(Some(data)),
+                                Some(Err(e)) => {
+                                    #[cfg(feature = "logging")]
+                                    tracing::error!("decode upstream response error {:?}", e);
+                                    self.open = false;
+                                    return (Err(e), false);
                                 }
-                                *using = false;
-                                let payload = Payload::Fixed(payload);
-                                let response = Response::from_parts(parts, payload.into());
-                                (Ok(response), false)
-                            }
-                            PayloadDecoder::Streamed(_) => {
-                                let mut framed_payload = payload_decoder.with_io(framed);
-                                let (payload, mut payload_sender) = stream_payload_pair();
-                                loop {
-                                    match framed_payload.next_data().await {
-                                        Some(Ok(data)) => payload_sender.feed_data(Some(data)),
-                                        Some(Err(e)) => {
-                                            #[cfg(feature = "logging")]
-                                            tracing::error!(
-                                                "decode upstream response error {:?}",
-                                                e
-                                            );
-                                            *open = false;
-                                            return (Err(e), false);
-                                        }
-                                        None => {
-                                            payload_sender.feed_data(None);
-                                            break;
-                                        }
-                                    }
+                                None => {
+                                    payload_sender.feed_data(None);
+                                    break;
                                 }
-                                *using = false;
-                                let payload = Payload::Stream(payload);
-                                let response = Response::from_parts(parts, payload.into());
-                                (Ok(response), false)
                             }
                         }
-                    }
-                    Some(Err(e)) => {
-                        #[cfg(feature = "logging")]
-                        tracing::error!("decode upstream response error {:?}", e);
-                        *open = false;
-                        *using = false;
-                        (Err(e), false)
-                    }
-                    None => {
-                        #[cfg(feature = "logging")]
-                        tracing::error!("upstream return eof");
-                        *open = false;
-                        *using = false;
-                        (Err(DecodeError::UnexpectedEof.into()), false)
+                        let payload = Payload::Stream(payload);
+                        let response = Response::from_parts(parts, payload.into());
+                        (Ok(response), false)
                     }
                 }
             }
+            Some(Err(e)) => {
+                #[cfg(feature = "logging")]
+                tracing::error!("decode upstream response error {:?}", e);
+                self.open = false;
+                (Err(e), false)
+            }
+            None => {
+                #[cfg(feature = "logging")]
+                tracing::error!("upstream return eof");
+                self.open = false;
+                (Err(DecodeError::UnexpectedEof.into()), false)
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Http2Connection {
+    tx: SendRequest<Bytes>,
+}
+
+impl Poolable for Http2Connection {
+    #[inline]
+    fn is_open(&self) -> bool {
+        !self.tx.has_conn_error()
+    }
+}
+
+impl Http2Connection {
+    pub fn new(tx: SendRequest<Bytes>) -> Self {
+        Self { tx }
+    }
+
+    #[allow(dead_code)]
+    fn to_owned(&self) -> Self {
+        Self {
+            tx: self.tx.clone(),
+        }
+    }
+
+    pub fn conn_error(&self) -> Option<HttpError> {
+        self.tx.conn_error()
+    }
+}
+
+impl Http2Connection {
+    pub async fn send_request<R>(
+        &mut self,
+        request: R,
+    ) -> (Result<Response<HttpBody>, HttpError>, bool)
+    where
+        R: IntoParts<Parts = RequestHead>,
+        R::Body: Body<Data = Bytes, Error = HttpError>,
+    {
+        let mut client = match self.tx.clone().ready().await {
+            Ok(client) => client,
+            Err(e) => {
+                return (Err(e.into()), false);
+            }
+        };
+
+        let (parts, mut body) = request.into_parts();
+        let h2_request = Request::from_parts(parts, ());
+
+        let (response, mut send_stream) = match client.send_request(h2_request, false) {
+            Ok((response, send_stream)) => (response, send_stream),
+            Err(e) => {
+                return (Err(e.into()), false);
+            }
+        };
+
+        while let Some(data) = body.next_data().await {
+            match data {
+                Ok(data) => {
+                    if let Err(e) = send_stream.send_data(data, false) {
+                        #[cfg(feature = "logging")]
+                        tracing::error!("H2 client body send error {:?}", e);
+                        return (Err(e.into()), false);
+                    }
+                }
+                Err(e) => {
+                    #[cfg(feature = "logging")]
+                    tracing::error!("H2 request body stream error {:?}", e);
+                    return (Err(e), false);
+                }
+            }
+        }
+        // Mark end of stream
+        let _ = send_stream.send_data(Bytes::new(), true);
+
+        let response = match response.await {
+            Ok(response) => response,
+            Err(e) => {
+                #[cfg(feature = "logging")]
+                tracing::error!("H2 client response error {:?}", e);
+                return (Err(e.into()), false);
+            }
+        };
+
+        let (parts, body) = response.into_parts();
+        (Ok(Response::from_parts(parts, body.into())), true)
+    }
+}
+
+pub enum HttpConnection<K: Key, IO: AsyncReadRent + AsyncWriteRent> {
+    Http1(Pooled<K, Http1Connection<IO>>),
+    Http2(Http2Connection),
+}
+
+impl<K: Key, IO: AsyncWriteRent + AsyncReadRent> Poolable for HttpConnection<K, IO> {
+    #[inline]
+    fn is_open(&self) -> bool {
+        match self {
+            Self::Http1(conn) => conn.is_open(),
+            Self::Http2(conn) => conn.is_open(),
+        }
+    }
+}
+
+impl<K: Key, IO: AsyncReadRent + AsyncWriteRent> From<Pooled<K, Http1Connection<IO>>>
+    for HttpConnection<K, IO>
+{
+    fn from(pooled_conn: Pooled<K, Http1Connection<IO>>) -> Self {
+        Self::Http1(pooled_conn)
+    }
+}
+
+impl<K: Key, IO: AsyncReadRent + AsyncWriteRent> From<Http2Connection> for HttpConnection<K, IO> {
+    fn from(conn: Http2Connection) -> Self {
+        Self::Http2(conn)
+    }
+}
+
+impl<K: Key, IO: AsyncReadRent + AsyncWriteRent> HttpConnection<K, IO> {
+    pub async fn send_request<R, E>(
+        &mut self,
+        request: R,
+    ) -> (Result<Response<HttpBody>, HttpError>, bool)
+    where
+        ClientCodec<IO>: Sink<R, Error = E>,
+        E: std::fmt::Debug + Into<HttpError>,
+        R: IntoParts<Parts = RequestHead>,
+        R::Body: Body<Data = Bytes, Error = HttpError>,
+    {
+        match self {
+            Self::Http1(conn) => conn.send_request(request).await,
+            Self::Http2(conn) => conn.send_request(request).await,
         }
     }
 }

--- a/src/http/connector.rs
+++ b/src/http/connector.rs
@@ -159,7 +159,7 @@ impl<C: Default, K: 'static, IO: AsyncWriteRent + 'static> HttpConnector<TlsConn
     /// let connector = HttpConnector::build_tls_http1_only();
     /// ```
     pub fn build_tls_http1_only() -> Self {
-        let alpn = vec![b"http/1.1".to_vec()];
+        let alpn = vec!["http/1.1"];
         let tls_connector = TlsConnector::new_with_tls_default(C::default(), Some(alpn));
         Self {
             connector: tls_connector,
@@ -181,7 +181,7 @@ impl<C: Default, K: 'static, IO: AsyncWriteRent + 'static> HttpConnector<TlsConn
     /// let connector = HttpConnector::build_tls_http2_only();
     /// ```
     pub fn build_tls_http2_only() -> Self {
-        let alpn = vec![b"h2".to_vec()];
+        let alpn = vec!["h2"];
         let tls_connector = TlsConnector::new_with_tls_default(C::default(), Some(alpn));
         Self {
             connector: tls_connector,

--- a/src/http/connector.rs
+++ b/src/http/connector.rs
@@ -1,114 +1,275 @@
-use std::time::Duration;
+use std::{cell::UnsafeCell, collections::HashMap, rc::Rc};
 
 use monoio::io::{AsyncReadRent, AsyncWriteRent, Split};
-use monoio_http::h1::codec::ClientCodec;
+use monoio_http::{h1::codec::ClientCodec, h2::client::Builder as MonoioH2Builder};
 
-use super::connection::HttpConnection;
+use super::connection::{Http1Connection, Http2Connection, HttpConnection};
 use crate::{
-    connectors::Connector,
+    connectors::{Connector, TcpConnector, TlsConnector, TransportConnMeta, TransportConnMetadata},
     pool::{ConnectionPool, Key, Pooled},
 };
 
-/// H1 connector with optional connection pool.
-// Note: here we don't use pooled::connector::PooledConnector.
-// In the future, it is expected to implement h2 connector(which mainly based on
-// ConnectionPool::map_ref) and unify the two connectors(not like hyper-util which merges at pool
-// level).
-pub struct H1Connector<C, K, IO: AsyncWriteRent> {
-    inner_connector: C,
-    pool: Option<ConnectionPool<K, HttpConnection<IO>>>,
-    pub read_timeout: Option<Duration>,
+#[derive(Debug, Default, Copy, Clone)]
+enum Protocol {
+    HTTP2,
+    HTTP11,
+    #[default]
+    Auto,
 }
 
-impl<C: Clone, K, IO: AsyncWriteRent> Clone for H1Connector<C, K, IO> {
-    fn clone(&self) -> Self {
+/// `HttpConnector` is a universal connector supporting both HTTP/1.1 and HTTP/2 protocols.
+/// It can be used with a `TlsConnector` for HTTPS connections.
+///
+/// ## Protocol Selection
+/// The protocol used depends on the context:
+///
+/// - When used with a `TlsConnector`, the protocol is determined by the ALPN negotiation. The
+///   default `TlsConnector` sets the client's ALPN advertisement to `h2` and `http/1.1`.
+///
+/// - For plain text HTTP, the default protocol is HTTP/1.1 unless the user specifically sets the
+///   client to a particular protocol.
+///
+/// | Connector Type | Protocol | Method | Example | Description |
+/// | --- | --- | --- | --- | --- |
+/// | `TcpConnector` | HTTP/1.1 | `build_tcp_http1_only()` | ```rust<br>let connector = HttpConnector::build_tcp_http1_only();<br>``` | Creates an `HttpConnector` that only supports HTTP/1.1 over TCP. |
+/// | `TcpConnector` | HTTP/2 | `build_tcp_http2_only()` | ```rust<br>let connector = HttpConnector::build_tcp_http2_only();<br>``` | Creates an `HttpConnector` that only supports HTTP/2 over TCP. |
+/// | `TlsConnector` | HTTP/1.1 and HTTP/2 | `default()` | ```rust<br>let connector: HttpConnector<TlsConnector<TcpConnector>, _, _> = HttpConnector::default();<br>``` | Creates a `HttpConnector` that supports both HTTP/1.1 and HTTP/2. |
+/// | `TlsConnector` | HTTP/1.1 | `build_tls_http1_only()` | ```rust<br>let connector = HttpConnector::build_tls_http1_only();<br>``` | Creates an `HttpConnector` with a `TlsConnector` that only supports HTTP/1.1. |
+/// | `TlsConnector` | HTTP/2 | `build_tls_http2_only()` | ```rust<br>let connector = HttpConnector::build_tls_http2_only();<br>``` | Creates an `HttpConnector` with a `TlsConnector` that only supports HTTP/2. |
+pub struct HttpConnector<C, K, IO: AsyncWriteRent> {
+    connector: C,
+    protocol: Protocol, // User configured protocol
+    h1_pool: Option<ConnectionPool<K, Http1Connection<IO>>>,
+    h2_pool: ConnectionPool<K, Http2Connection>,
+    connecting: UnsafeCell<HashMap<K, Rc<local_sync::semaphore::Semaphore>>>,
+    h2_builder: MonoioH2Builder,
+}
+
+impl<C, K: 'static, IO: AsyncWriteRent + 'static> HttpConnector<C, K, IO> {
+    #[inline]
+    pub fn new(connector: C) -> Self {
         Self {
-            inner_connector: self.inner_connector.clone(),
-            pool: self.pool.clone(),
-            read_timeout: self.read_timeout,
+            connector,
+            protocol: Protocol::default(),
+            h1_pool: Some(ConnectionPool::default()),
+            h2_pool: ConnectionPool::new(None),
+            connecting: UnsafeCell::new(HashMap::new()),
+            h2_builder: MonoioH2Builder::default(),
+        }
+    }
+
+    /// Sets the protocol of the `HttpConnector` to HTTP/1.1 only.
+    ///
+    /// This method should be used with non-TLS connectors like `TcpConnector`, `UdsConnector`, etc.
+    /// For TLS connectors, use `build_tls_http1_only` instead to set the correct ALPN.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let mut connector = HttpConnector::new(TcpConnector::new());
+    /// connector.set_http1_only();
+    /// ```
+    pub fn set_http1_only(&mut self) {
+        self.protocol = Protocol::HTTP11
+    }
+
+    /// Sets the protocol of the `HttpConnector` to HTTP/2 only.
+    ///
+    /// This method should be used with non-TLS connectors like `TcpConnector`, `UdsConnector`, etc.
+    /// For TLS connectors, use `build_tls_http2_only` instead to set the correct ALPN.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let mut connector = HttpConnector::new(TcpConnector::new());
+    /// connector.set_http2_only();
+    /// ```
+    pub fn set_http2_only(&mut self) {
+        self.protocol = Protocol::HTTP2
+    }
+
+    #[inline]
+    pub fn h2_builder(&mut self) -> &mut MonoioH2Builder {
+        &mut self.h2_builder
+    }
+
+    fn is_config_h2(&self) -> bool {
+        matches!(self.protocol, Protocol::HTTP2)
+    }
+}
+
+impl<K: 'static, IO: AsyncWriteRent + 'static> HttpConnector<TcpConnector, K, IO> {
+    /// Builds a new `HttpConnector` with a `TcpConnector` that supports only HTTP/1.1.
+    ///
+    /// This method sets the protocol of the `HttpConnector` to HTTP/1.1 only.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let connector = HttpConnector::build_tcp_http1_only();
+    /// ```
+    pub fn build_tcp_http1_only() -> Self {
+        Self {
+            connector: TcpConnector::default(),
+            protocol: Protocol::HTTP11,
+            h1_pool: Some(ConnectionPool::default()),
+            h2_pool: ConnectionPool::new(None),
+            connecting: UnsafeCell::new(HashMap::new()),
+            h2_builder: MonoioH2Builder::default(),
+        }
+    }
+
+    /// Builds a new `HttpConnector` with a `TcpConnector` that supports only HTTP/2.
+    ///
+    /// This method sets the protocol of the `HttpConnector` to HTTP/2 only.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let connector = HttpConnector::build_tcp_http2_only();
+    /// ```
+    pub fn build_tcp_http2_only() -> Self {
+        Self {
+            connector: TcpConnector::default(),
+            protocol: Protocol::HTTP2,
+            h1_pool: Some(ConnectionPool::default()),
+            h2_pool: ConnectionPool::new(None),
+            connecting: UnsafeCell::new(HashMap::new()),
+            h2_builder: MonoioH2Builder::default(),
         }
     }
 }
 
-impl<C, K, IO: AsyncWriteRent> H1Connector<C, K, IO> {
-    #[inline]
-    pub const fn new(inner_connector: C) -> Self {
+impl<C: Default, K: 'static, IO: AsyncWriteRent + 'static> HttpConnector<TlsConnector<C>, K, IO> {
+    /// Builds a new `HttpConnector` with a `TlsConnector` that supports only HTTP/1.1.
+    ///
+    /// This method sets the client's ALPN advertisement to `http/1.1`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let connector = HttpConnector::build_tls_http1_only();
+    /// ```
+    pub fn build_tls_http1_only() -> Self {
+        let alpn = vec![b"http/1.1".to_vec()];
+        let tls_connector = TlsConnector::new_with_tls_default(C::default(), Some(alpn));
         Self {
-            inner_connector,
-            pool: None,
-            read_timeout: None,
+            connector: tls_connector,
+            protocol: Protocol::default(),
+            h1_pool: Some(ConnectionPool::default()),
+            h2_pool: ConnectionPool::new(None),
+            connecting: UnsafeCell::new(HashMap::new()),
+            h2_builder: MonoioH2Builder::default(),
         }
     }
 
-    #[inline]
-    pub const fn new_with_timeout(inner_connector: C, timeout: Duration) -> Self {
+    /// Builds a new `HttpConnector` with a `TlsConnector` that supports only HTTP/2.
+    ///
+    /// This method sets the client's ALPN advertisement to `h2`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let connector = HttpConnector::build_tls_http2_only();
+    /// ```
+    pub fn build_tls_http2_only() -> Self {
+        let alpn = vec![b"h2".to_vec()];
+        let tls_connector = TlsConnector::new_with_tls_default(C::default(), Some(alpn));
         Self {
-            inner_connector,
-            pool: None,
-            read_timeout: Some(timeout),
+            connector: tls_connector,
+            protocol: Protocol::default(),
+            h1_pool: Some(ConnectionPool::default()),
+            h2_pool: ConnectionPool::new(None),
+            connecting: UnsafeCell::new(HashMap::new()),
+            h2_builder: MonoioH2Builder::default(),
         }
-    }
-
-    #[inline]
-    pub fn pool(&mut self) -> &mut Option<ConnectionPool<K, HttpConnection<IO>>> {
-        &mut self.pool
-    }
-
-    #[inline]
-    pub fn read_timeout(&mut self) -> &mut Option<Duration> {
-        &mut self.read_timeout
     }
 }
 
-impl<C, K: 'static, IO: AsyncWriteRent + 'static> H1Connector<C, K, IO> {
-    #[inline]
-    pub fn with_default_pool(self) -> Self {
-        Self {
-            pool: Some(ConnectionPool::default()),
-            ..self
-        }
-    }
-}
-
-impl<C: Default, K, IO: AsyncWriteRent> Default for H1Connector<C, K, IO> {
+impl<C: Default, K: 'static, IO: AsyncWriteRent + 'static> Default for HttpConnector<C, K, IO> {
     #[inline]
     fn default() -> Self {
-        H1Connector::new(C::default())
+        HttpConnector::new(C::default())
     }
 }
 
-impl<C, K: Key, IO: AsyncWriteRent> Connector<K> for H1Connector<C, K, IO>
+macro_rules! try_get {
+    ($self:ident, $pool:ident, $key:ident) => {
+        $self.$pool.and_then_mut(&$key, |conns| {
+            conns.retain(|idle| {
+                // Remove any connections that have errored
+                match idle.conn.conn_error() {
+                    Some(_e) => {
+                        println!("Removing connection");
+                        #[cfg(feature = "logging")]
+                        tracing::debug!("Removing invalid connection: {:?}", _e);
+                        false
+                    }
+                    None => true,
+                }
+            });
+
+            conns.front().map(|idle| idle.conn.to_owned())
+        })
+    };
+}
+
+impl<C, K: Key, IO> Connector<K> for HttpConnector<C, K, IO>
 where
     C: Connector<K, Connection = IO>,
-    // TODO: Remove AsyncReadRent after monoio-http new version published.
-    IO: AsyncReadRent + AsyncWriteRent + Split,
+    C::Connection: TransportConnMetadata<Metadata = TransportConnMeta>,
+    crate::TransportError: From<C::Error>,
+    IO: AsyncReadRent + AsyncWriteRent + Split + Unpin + 'static,
 {
-    type Connection = Pooled<K, HttpConnection<IO>>;
-    type Error = C::Error;
+    type Connection = HttpConnection<K, IO>;
+    type Error = crate::TransportError;
 
-    #[inline]
     async fn connect(&self, key: K) -> Result<Self::Connection, Self::Error> {
-        if let Some(pool) = &self.pool {
-            if let Some(conn) = pool.get(&key) {
-                return Ok(conn);
+        if let Some(conn) = try_get!(self, h2_pool, key) {
+            return Ok(conn.into());
+        }
+
+        if let Some(h1_pool) = &self.h1_pool {
+            if let Some(h1_pooled) = h1_pool.get(&key) {
+                return Ok(h1_pooled.into());
             }
         }
-        let io: IO = self.inner_connector.connect(key.clone()).await?;
-        let client_codec = match self.read_timeout {
-            Some(timeout) => ClientCodec::new_with_timeout(io, timeout),
-            None => ClientCodec::new(io),
-        };
-        let http_conn = HttpConnection::H1 {
-            framed: client_codec,
-            open: true,
-            using: false,
-        };
-        let pooled = if let Some(pool) = &self.pool {
-            pool.link(key, http_conn)
+
+        // We use ALPN to determine if connector should use HTTP/2 codecs or HTTP/1.1
+        let transport_conn = self.connector.connect(key.clone()).await?;
+        let conn_meta = transport_conn.get_conn_metadata();
+
+        let connect_to_h2 = self.is_config_h2() || conn_meta.is_alpn_h2();
+
+        if connect_to_h2 {
+            let lock = {
+                let connecting = unsafe { &mut *self.connecting.get() };
+                let lock = connecting
+                    .entry(key.clone())
+                    .or_insert_with(|| Rc::new(local_sync::semaphore::Semaphore::new(1)));
+                lock.clone()
+            };
+
+            // get lock and try again
+            let _guard = lock.acquire().await?;
+            if let Some(conn) = try_get!(self, h2_pool, key) {
+                return Ok(conn.into());
+            }
+
+            let (tx, conn) = self.h2_builder.handshake(transport_conn).await?;
+            monoio::spawn(conn);
+            self.h2_pool.put(key, Http2Connection::new(tx.clone()));
+            Ok(Http2Connection::new(tx.clone()).into())
         } else {
-            Pooled::unpooled(http_conn)
-        };
-        Ok(pooled)
+            let client_codec = ClientCodec::new(transport_conn);
+            let http_conn = Http1Connection::new(client_codec);
+            let pooled = if let Some(pool) = &self.h1_pool {
+                pool.link(key, http_conn)
+            } else {
+                Pooled::unpooled(http_conn)
+            };
+            Ok(pooled.into())
+        }
     }
 }
 
@@ -120,23 +281,97 @@ mod tests {
     use monoio_http::{common::body::HttpBody, h1::payload::Payload};
 
     use super::*;
-    use crate::connectors::{TcpConnector, TcpTlsAddr, TlsConnector};
+    use crate::connectors::{TcpConnector, TcpTlsAddr};
 
     #[monoio::test(enable_timer = true)]
-    async fn test_http_connector() -> Result<(), crate::Error> {
-        let connector = H1Connector {
-            inner_connector: TcpConnector::default(),
-            pool: None,
-            read_timeout: None,
+    async fn test_default_https_connector() -> Result<(), crate::TransportError> {
+        let connector: HttpConnector<TlsConnector<TcpConnector>, _, _> = HttpConnector::default();
+
+        let uri = "https://httpbin.org/get".parse::<Uri>().unwrap();
+        let addr: TcpTlsAddr = uri.try_into().unwrap();
+        let mut conn = connector.connect(addr).await.unwrap();
+
+        for _ in 0..10 {
+            let req = request::Builder::new()
+                .uri("/get")
+                .header("Host", "httpbin.org")
+                .body(HttpBody::H1(Payload::None))
+                .unwrap();
+            let (res, _) = conn.send_request(req).await;
+            let resp = res?;
+            assert_eq!(200, resp.status());
+            assert_eq!(
+                "application/json".as_bytes(),
+                resp.headers().get("content-type").unwrap().as_bytes()
+            );
+            assert_eq!(resp.version(), http::Version::HTTP_2);
         }
-        .with_default_pool();
+        Ok(())
+    }
+
+    #[monoio::test(enable_timer = true)]
+    async fn test_http2_tls_connector() -> Result<(), crate::TransportError> {
+        let connector: HttpConnector<TlsConnector<TcpConnector>, _, _> =
+            HttpConnector::build_tls_http2_only();
+
+        let uri = "https://httpbin.org/get".parse::<Uri>().unwrap();
+        let addr: TcpTlsAddr = uri.try_into().unwrap();
+        let mut conn = connector.connect(addr).await.unwrap();
+
+        for _ in 0..10 {
+            let req = request::Builder::new()
+                .uri("/get")
+                .header("Host", "httpbin.org")
+                .body(HttpBody::H1(Payload::None))
+                .unwrap();
+            let (res, _) = conn.send_request(req).await;
+            let resp = res?;
+            assert_eq!(200, resp.status());
+            assert_eq!(
+                "application/json".as_bytes(),
+                resp.headers().get("content-type").unwrap().as_bytes()
+            );
+            assert_eq!(resp.version(), http::Version::HTTP_2);
+        }
+        Ok(())
+    }
+
+    #[monoio::test(enable_timer = true)]
+    async fn test_http1_tls_connector() -> Result<(), crate::TransportError> {
+        let connector: HttpConnector<TlsConnector<TcpConnector>, _, _> =
+            HttpConnector::build_tls_http1_only();
+
+        let uri = "https://httpbin.org/get".parse::<Uri>().unwrap();
+        let addr: TcpTlsAddr = uri.try_into().unwrap();
+        let mut conn = connector.connect(addr).await.unwrap();
+
+        for _ in 0..10 {
+            let req = request::Builder::new()
+                .uri("/get")
+                .header("Host", "httpbin.org")
+                .body(HttpBody::H1(Payload::None))
+                .unwrap();
+            let (res, _) = conn.send_request(req).await;
+            let resp = res?;
+            assert_eq!(200, resp.status());
+            assert_eq!(
+                "application/json".as_bytes(),
+                resp.headers().get("content-type").unwrap().as_bytes()
+            );
+            assert_eq!(resp.version(), http::Version::HTTP_11);
+        }
+        Ok(())
+    }
+
+    #[monoio::test(enable_timer = true)]
+    async fn test_http1_tcp_connector() -> Result<(), crate::TransportError> {
+        let connector: HttpConnector<TcpConnector, _, _> = HttpConnector::default();
 
         #[derive(Debug, Clone, Eq, PartialEq, Hash)]
         struct Key {
             host: String,
             port: u16,
         }
-
         impl ToSocketAddrs for Key {
             type Iter = std::vec::IntoIter<std::net::SocketAddr>;
             fn to_socket_addrs(&self) -> std::io::Result<Self::Iter> {
@@ -144,7 +379,7 @@ mod tests {
             }
         }
 
-        for i in 0..3 {
+        for _i in 0..10 {
             let uri = "http://httpbin.org/get".parse::<Uri>().unwrap();
             let host = uri.host().unwrap();
             let port = uri.port_u16().unwrap_or(80);
@@ -153,7 +388,7 @@ mod tests {
                 port,
             };
             let mut conn = connector.connect(key).await.unwrap();
-            assert!((i == 0) ^ conn.is_reused());
+            // assert!((i == 0) ^ conn.is_reused());
 
             let req = request::Builder::new()
                 .uri("/get")
@@ -167,29 +402,9 @@ mod tests {
                 "application/json".as_bytes(),
                 resp.headers().get("content-type").unwrap().as_bytes()
             );
+            assert_eq!(resp.version(), http::Version::HTTP_11);
         }
-
         Ok(())
     }
-
-    #[monoio::test(enable_timer = true)]
-    async fn test_https_connector() -> Result<(), crate::Error> {
-        let connector: H1Connector<TlsConnector<TcpConnector>, _, _> = H1Connector::default();
-        let uri = "https://httpbin.org/get".parse::<Uri>().unwrap();
-        let addr: TcpTlsAddr = uri.try_into().unwrap();
-        let mut conn = connector.connect(addr).await.unwrap();
-        let req = request::Builder::new()
-            .uri("/get")
-            .header("Host", "httpbin.org")
-            .body(HttpBody::H1(Payload::None))
-            .unwrap();
-        let (res, _) = conn.send_request(req).await;
-        let resp = res?;
-        assert_eq!(200, resp.status());
-        assert_eq!(
-            "application/json".as_bytes(),
-            resp.headers().get("content-type").unwrap().as_bytes()
-        );
-        Ok(())
-    }
+    // See http_with_tcp for plain text HTTP/2 example
 }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -2,7 +2,7 @@ mod connection;
 mod connector;
 
 pub use connection::HttpConnection;
-pub use connector::H1Connector;
+pub use connector::HttpConnector;
 
 #[cfg(feature = "hyper")]
 pub mod hyper;


### PR DESCRIPTION
This PR introduces a new `HttpConnector` that supports both HTTP/1.1 and HTTP/2 protocols. This universal connector can be used with a `TlsConnector` for HTTPS connections.

The protocol used by the HttpConnector depends on the context:

- For HTTPS connections, the protocol is determined by the ALPN negotiation. The default `TlsConnector` sets the client's ALPN advertisement to h2 and http/1.1.
- For plain text HTTP connections, the default protocol is HTTP/1.1 unless the user specifically sets the client to use HTTP/2.

This PR also introduces a new trait, `TransportConnMetadata`, which provides additional information about the connection. This is particularly useful for transport connectors like TLS, TCP, UDS, etc. The `get_conn_metadata` method is used to retrieve the metadata from the connection. 

| Connector Type | Protocol | Method | Example | Description |
| --- | --- | --- | --- | --- |
| `TcpConnector` | HTTP/1.1 | `build_tcp_http1_only()` | `let connector = HttpConnector::build_tcp_http1_only();` | Creates an `HttpConnector` that only supports HTTP/1.1 over TCP. |
| `TcpConnector` | HTTP/2 | `build_tcp_http2_only()` | `let connector = HttpConnector::build_tcp_http2_only();` | Creates an `HttpConnector` that only supports HTTP/2 over TCP. |
| `TlsConnector` | HTTP/1.1 and HTTP/2 | `default()` | `let connector: HttpConnector<TlsConnector<TcpConnector>, _, _> = HttpConnector::default();` | Creates a `HttpConnector` that supports both HTTP/1.1 and HTTP/2. |
| `TlsConnector` | HTTP/1.1 | `build_tls_http1_only()` | `let connector = HttpConnector::build_tls_http1_only();` | Creates an `HttpConnector` with a `TlsConnector` that only supports HTTP/1.1. |
| `TlsConnector` | HTTP/2 | `build_tls_http2_only()` | `let connector = HttpConnector::build_tls_http2_only();` | Creates an `HttpConnector` with a `TlsConnector` that only supports HTTP/2. |

PR also includes changes to accomodate rusttls version bump.