### PR TITLE
Revert "Fix: Simplify trait bounds for HttpConnection (#28)"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Monoio Transporter."
 edition = "2021"
 license = "MIT/Apache-2.0"
 name = "monoio-transports"
-version = "0.5.1"
+version = "0.5.0"
 
 [dependencies]
 monoio = "0.2.3"


### PR DESCRIPTION
This reverts commit 8e0104a287b71d7d0a30220c24c2175dfd016690.