### PR TITLE
Feat: Optimization to add add idle connecections directly to queue

### DIFF
--- a/src/connectors/l4_connector.rs
+++ b/src/connectors/l4_connector.rs
@@ -32,12 +32,11 @@ impl<T: ToSocketAddrs> Connector<T> for TcpConnector {
 
     #[inline]
     async fn connect(&self, key: T) -> Result<Self::Connection, Self::Error> {
-        TcpStream::connect(key).await.map(|io| {
+        TcpStream::connect(key).await.inspect(|io| {
             if self.no_delay {
                 // we will ignore the set nodelay error
                 let _ = io.set_nodelay(true);
             }
-            io
         })
     }
 }

--- a/src/connectors/l4_connector.rs
+++ b/src/connectors/l4_connector.rs
@@ -32,11 +32,12 @@ impl<T: ToSocketAddrs> Connector<T> for TcpConnector {
 
     #[inline]
     async fn connect(&self, key: T) -> Result<Self::Connection, Self::Error> {
-        TcpStream::connect(key).await.inspect(|io| {
+        TcpStream::connect(key).await.map(|io| {
             if self.no_delay {
                 // we will ignore the set nodelay error
                 let _ = io.set_nodelay(true);
             }
+            io
         })
     }
 }

--- a/src/connectors/mod.rs
+++ b/src/connectors/mod.rs
@@ -1,9 +1,10 @@
 //! Defines core traits and types for creating and composing network connectors.
 //!
-//! This module provides the [`Connector`](Connector) trait for establishing connections,
-//! the `ConnectorExt` trait for adding t//! [`TransportConnMetadata`](TransportConnMetadata) trait
-//! for retrieving connection metadata. It also includes types for ALPN negotiation and connection
-//! metadata.
+//! This module provides the following key components:
+//!
+//! - The [`Connector`] trait for establishing connections
+//! - The [`ConnectorExt`] trait for adding timeout functionality
+//! - The [`TransportConnMetadata`] trait for retrieving connection metadata
 mod l4_connector;
 #[cfg(feature = "hyper")]
 pub mod pollio;
@@ -14,8 +15,7 @@ use std::{future::Future, time::Duration};
 pub use l4_connector::*;
 pub use tls_connector::*;
 
-/// The [`Connector`](Conenctor) trait defines an interface for establishing connections.
-///
+/// The [`Connector`] trait defines an interface for establishing connections.
 /// This trait is designed to be composable, allowing for the creation of modular
 /// and stackable connectors. Each connector in the stack can add its own layer
 /// of functionality, such as TCP connection, Unix Domain Socket (UDS) connection,

--- a/src/connectors/mod.rs
+++ b/src/connectors/mod.rs
@@ -1,8 +1,9 @@
 //! Defines core traits and types for creating and composing network connectors.
 //!
 //! This module provides the [`Connector`](Connector) trait for establishing connections,
-//! the `ConnectorExt` trait for adding t//! [`TransportConnMetadata`](TransportConnMetadata) trait for retrieving connection
-//! metadata. It also includes types for ALPN negotiation and connection metadata.
+//! the `ConnectorExt` trait for adding t//! [`TransportConnMetadata`](TransportConnMetadata) trait
+//! for retrieving connection metadata. It also includes types for ALPN negotiation and connection
+//! metadata.
 mod l4_connector;
 #[cfg(feature = "hyper")]
 pub mod pollio;

--- a/src/connectors/tls_connector.rs
+++ b/src/connectors/tls_connector.rs
@@ -420,7 +420,7 @@ impl<'a> Connector<&'a UnifiedAddr> for UnifiedConnector {
                     .tls_connector
                     .connect(sn.clone(), stream)
                     .await
-                    .map_err(|e| UnifiedError::Tls(TlsError::from(e)))?;
+                    .map_err(UnifiedError::Tls)?;
                 #[cfg(feature = "native-tls")]
                 let tls_stream = self
                     .0

--- a/src/http/connector.rs
+++ b/src/http/connector.rs
@@ -208,7 +208,7 @@ impl<C: Default, K: 'static, IO: AsyncWriteRent + 'static> Default for HttpConne
 
 macro_rules! try_get {
     ($self:ident, $pool:ident, $key:ident) => {
-        $self.$pool.and_then_mut(&$key, |conns| {
+        $self.$pool.and_then_mut(&$key, |mut conns| {
             conns.retain(|idle| {
                 // Remove any connections that have errored
                 match idle.conn.conn_error() {

--- a/src/http/hyper/mod.rs
+++ b/src/http/hyper/mod.rs
@@ -353,7 +353,7 @@ where
     async fn connect(&self, key: K) -> Result<Self::Connection, Self::Error> {
         macro_rules! try_get {
             ($pool:expr, $key:expr) => {
-                if let Some(pooled) = $pool.and_then_mut($key, |conns| {
+                if let Some(pooled) = $pool.and_then_mut($key, |mut conns| {
                     // remove invalid conn
                     conns.retain(|idle| idle.conn.is_ready());
                     // check count

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -6,13 +6,12 @@
 //!
 //! # Key Components
 //!
-//! - [`HttpConnection`](HttpConnection): A unified enum representing either an HTTP/1.1 or HTTP/2
-//!   connection. It provides a common interface for sending requests regardless of the underlying
-//!   protocol.
+//! - [`HttpConnection`]: A unified enum representing either an HTTP/1.1 or HTTP/2 connection. It
+//!   provides a common interface for sending requests regardless of the underlying protocol.
 //!
-//! - [`HttpConnector`](HttpConnection): A universal connector supporting both HTTP/1.1 and HTTP/2
-//!   protocols. It can be used with a `TlsConnector` for HTTPS connections and is specifically
-//!   designed to work with monoio's native IO traits, which are built on top of io_uring.
+//! - [`HttpConnector`]: A universal connector supporting both HTTP/1.1 and HTTP/2 protocols. It can
+//!   be used with a `TlsConnector` for HTTPS connections and is specifically designed to work with
+//!   monoio's native IO traits, which are built on top of io_uring.
 //!
 //! - [`H1Connector`]: A deprecated HTTP/1.1 connector retained for backwards compatibility. New
 //!   code should use `HttpConnector` instead.
@@ -53,5 +52,5 @@ mod connector;
 pub use connection::HttpConnection;
 pub use connector::{H1Connector, HttpConnector};
 
-// #[cfg(feature = "hyper")]
-// pub mod hyper;
+#[cfg(feature = "hyper")]
+pub mod hyper;

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -6,12 +6,13 @@
 //!
 //! # Key Components
 //!
-//! - [`HttpConnection`](HttpConnection): A unified enum representing either an HTTP/1.1 or HTTP/2 connection. It
-//!   provides a common interface for sending requests regardless of the underlying protocol.
+//! - [`HttpConnection`](HttpConnection): A unified enum representing either an HTTP/1.1 or HTTP/2
+//!   connection. It provides a common interface for sending requests regardless of the underlying
+//!   protocol.
 //!
-//! - [`HttpConnector`](HttpConnection): A universal connector supporting both HTTP/1.1 and HTTP/2 protocols. It can
-//!   be used with a `TlsConnector` for HTTPS connections and is specifically designed to work with
-//!   monoio's native IO traits, which are built on top of io_uring.
+//! - [`HttpConnector`](HttpConnection): A universal connector supporting both HTTP/1.1 and HTTP/2
+//!   protocols. It can be used with a `TlsConnector` for HTTPS connections and is specifically
+//!   designed to work with monoio's native IO traits, which are built on top of io_uring.
 //!
 //! - [`H1Connector`]: A deprecated HTTP/1.1 connector retained for backwards compatibility. New
 //!   code should use `HttpConnector` instead.
@@ -26,8 +27,8 @@
 //!
 //! # Connector Types and Usage
 //!
-//! The [`HttpConnector`](HttpConnector) provides various methods to create connectors for different protocols
-//! and transport layers:
+//! The [`HttpConnector`](HttpConnector) provides various methods to create connectors for different
+//! protocols and transport layers:
 //!
 //! | Connector Type | Protocol | Method | Example | Description |
 //! | --- | --- | --- | --- | --- |
@@ -42,13 +43,15 @@
 //! When the `hyper` feature flag is enabled, this module provides additional connectors
 //! that integrate with the Hyper HTTP library:
 //!
-//! - [`HyperH1Connector`](hyper::HyperH1Conenctor): An HTTP/1.1 connector compatible with Hyper's interfaces.
-//! - [`HyperH2Connector`](hyper::HyperH2Conenctor): An HTTP/2 connector compatible with Hyper's interfaces.
+//! - [`HyperH1Connector`](hyper::HyperH1Conenctor): An HTTP/1.1 connector compatible with Hyper's
+//!   interfaces.
+//! - [`HyperH2Connector`](hyper::HyperH2Conenctor): An HTTP/2 connector compatible with Hyper's
+//!   interfaces.
 mod connection;
 mod connector;
 
 pub use connection::HttpConnection;
 pub use connector::{H1Connector, HttpConnector};
 
-#[cfg(feature = "hyper")]
-pub mod hyper;
+// #[cfg(feature = "hyper")]
+// pub mod hyper;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,9 @@
 //!
 //! ### TransportConnMetadata Trait
 //!
-//! The [`TransportConnMetadata`](crate::connectors::TransportConnMetadata) trait provides a way to retrieve additional information about
-//! a connection, such as ALPN (Application-Layer Protocol Negotiation) details:
+//! The [`TransportConnMetadata`](crate::connectors::TransportConnMetadata) trait provides a way to
+//! retrieve additional information about a connection, such as ALPN (Application-Layer Protocol
+//! Negotiation) details:
 //!
 //! ```rust
 //! pub trait TransportConnMetadata {


### PR DESCRIPTION
The current implementation of Monolake experiences performance issues with small payloads when connections are recycled at a high rate. When a connection is dropped, we currently perform a lookup in the shared pool's hashmap, followed by adding the connection back to the queue. This PR proposes a change to use a weak reference to the queue within the connection itself. By doing so, we eliminate the need for a hashmap lookup each time a connection is recycled, resulting in an 8% performance improvement in benchmarks with small HTTP payloads.